### PR TITLE
#1 Remove the activemodel dependency

### DIFF
--- a/json_path_attribute.gemspec
+++ b/json_path_attribute.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activemodel", "~> 7.2"
   spec.add_dependency "activesupport", "~> 7.2"
   spec.add_dependency "jsonpath", "~> 1.1"
 end

--- a/lib/json_path_attribute/type.rb
+++ b/lib/json_path_attribute/type.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_model"
-
 module JsonPathAttribute
   # Provides a way to cast values to a specific type
   # This class is intended to be used internally by JsonPathAttribute
@@ -9,36 +7,31 @@ module JsonPathAttribute
     class << self
       def cast_attribute(type, value, array: false)
         return value if type == :source
+
+        if value.nil?
+          return [] if array
+          return false if type == :boolean
+        end
+
+        array ? cast_array(type, value) : cast_value(type, value, array)
+      end
+
+      def cast_value(type, value, array)
         return cast_object_attribute(type, value, array: array) if type.is_a?(Class)
+        return false if type == :boolean && value.nil?
 
-        cast_to(type, value, array: array)
-      end
-
-      def cast_to(type, value, array: false)
-        return [] if value.nil? && array
-        return false if value.nil? && type == :boolean
-
-        cast_type = ActiveModel::Type.lookup(type)
-
-        if array
-          cast_array(value, type, cast_type)
+        case type
+        when :string, :decimal
+          value.to_s
+        when :integer
+          value.to_i
         else
-          cast_value(value, type, cast_type)
+          raise TypeError, "Unable to cast #{value.inspect} to #{type}"
         end
       end
 
-      def cast_array(values, type, cast_type)
-        values.map do |value|
-          next false if value.nil? && type == :boolean
-
-          cast_type.cast(value)
-        end
-      end
-
-      def cast_value(value, type, cast_type)
-        value = value.to_s if type == :decimal && value.is_a?(Float)
-
-        cast_type.cast(value)
+      def cast_array(type, values)
+        values.map { |element| cast_value(type, element, false) }
       end
 
       def cast_object_attribute(type, value, array:)

--- a/lib/json_path_attribute/version.rb
+++ b/lib/json_path_attribute/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JsonPathAttribute
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
We used it for casting the value to a defined type, but since we only support simple types like integers and strings, we can better use things like #to_i and #to_s.

The other data type we support are other classes that include JsonPathAttribute, so we can call .parse on those with the parsed values.