### PR TITLE
Allow active model and active support versions 8.x.x

### DIFF
--- a/json_path_attribute.gemspec
+++ b/json_path_attribute.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activemodel", "~> 7.2"
-  spec.add_dependency "activesupport", "~> 7.2"
+  spec.add_dependency "activemodel", ">= 7.2", "< 9.0"
+  spec.add_dependency "activesupport", ">= 7.2", "< 9.0"
   spec.add_dependency "jsonpath", "~> 1.1"
 end


### PR DESCRIPTION
By locking the versions to 7.2 we are not very flexible with current supported rails versions. I've tested with rails 8.1.1